### PR TITLE
Various fixes for triples.py.

### DIFF
--- a/.ci/pep8_sources.txt
+++ b/.ci/pep8_sources.txt
@@ -1,6 +1,7 @@
 lib/galaxy/auth
 lib/galaxy/config.py
 lib/galaxy/datatypes/data.py
+lib/galaxy/datatypes/triples.py
 lib/galaxy/exceptions/error_codes.py
 lib/galaxy/jobs/{__init__,error_level,manager,stock_rules}.py
 lib/galaxy/main.py

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -884,6 +884,20 @@ class Text( Data ):
         dataset_source = dataproviders.dataset.DatasetDataProvider( dataset )
         return dataproviders.line.RegexLineDataProvider( dataset_source, **settings )
 
+    def safe_readlines(self, path, num_lines=1, size=5 * 1024):
+        """
+        Read lines from the start of a file but be sure to restrict the size of
+        memory that will be consumed and use proper file handling to ensure file
+        handles aren't leaked.
+        """
+        with open(path, "r") as f:
+            start_of_file = f.read(size)
+            lines = start_of_file.splitlines()
+            return lines[0:num_lines]
+
+    def safe_readline(self, path):
+        self.safe_readlines(path)[0]
+
 
 class GenericAsn1( Text ):
     """Class for generic ASN.1 text format"""

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -46,6 +46,26 @@ class DataMeta( type ):
         metadata.Statement.process( cls )
 
 
+def deprecated_datatype_reference(klass):
+    """ Decorate an older class location to indicate that the class has been
+    moved to a new module. See graph.py as an example.
+    """
+    old_init = klass.__init__
+
+    def new_init(self, *args, **kwargs):
+        old_location = "%s.%s" % (klass.__module__, klass.__name__)
+        new_klass = klass.__bases__[0]
+        new_location = "%s.%s" % (new_klass.__module__, new_klass.__name__)
+        message = "Using deprecated reference to class [%s] " % old_location
+        message += "update datatype configuration to reference [%s]" % new_location
+        log.warn(message)
+        old_init(self, *args, **kwargs)
+
+    klass.__init__ = new_init
+
+    return klass
+
+
 @dataproviders.decorators.has_dataproviders
 class Data( object ):
     """

--- a/lib/galaxy/datatypes/graph.py
+++ b/lib/galaxy/datatypes/graph.py
@@ -8,6 +8,7 @@ import xml
 
 import dataproviders
 from galaxy.util import simplegraph
+from . import triples
 
 import logging
 log = logging.getLogger( __name__ )
@@ -159,3 +160,8 @@ class SIFGraphDataProvider( dataproviders.column.ColumnarDataProvider ):
                         graph.add_edge( source_id, target_id, type=relation )
 
         yield graph.as_dict()
+
+
+@data.deprecated_datatype_reference
+class Rdf(triples.Rdf):
+    pass

--- a/lib/galaxy/datatypes/triples.py
+++ b/lib/galaxy/datatypes/triples.py
@@ -41,9 +41,7 @@ class NTriples( Triples ):
     file_ext = "nt"
 
     def sniff( self, filename ):
-        handle = open(filename)
-        line = handle.readline()
-        handle.close()
+        line = self.safe_readline(filename)
 
         # @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         if re.compile( r'<[^>]*>\s<[^>]*>\s<[^>]*>\s\.' ).search( line ):
@@ -91,10 +89,7 @@ class Turtle( Triples ):
     file_ext = "ttl"
 
     def sniff( self, filename ):
-        handle = open(filename)
-        line = handle.readline()
-        handle.close()
-
+        line = self.safe_readline(filename)
         # @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         if re.compile( r'@prefix\s+[^:]*:\s+<[^>]*>\s\.' ).search( line ):
             return True
@@ -120,10 +115,7 @@ class Rdf( xml.GenericXml, Triples ):
     file_ext = "rdf"
 
     def sniff( self, filename ):
-        f = open( filename, "r" )
-        firstlines = "".join( f.readlines(5) )
-        f.close()
-
+        firstlines = self.safe_readlines(filename, 5)
         if "http://www.w3.org/1999/02/22-rdf-syntax-ns#" in firstlines and "RDF" in firstlines:
             return True
 
@@ -149,10 +141,7 @@ class Jsonld( text.Json, Triples ):
 
     def sniff( self, filename ):
         if self._looks_like_json( filename ):
-            f = open( filename, "r" )
-            firstlines = "".join( f.readlines(5) )
-            f.close()
-
+            firstlines = self.safe_readlines(filename, 5)
             if "\"@id\"" in firstlines or "\"@context\"" in firstlines:
                 return True
         return False

--- a/lib/galaxy/datatypes/triples.py
+++ b/lib/galaxy/datatypes/triples.py
@@ -4,14 +4,11 @@ Triple format classes
 import re
 import data
 import logging
-from galaxy.datatypes.sniff import *
-import dataproviders
 import xml
 import text
-import json
-import os
 
 log = logging.getLogger(__name__)
+
 
 class Triples( data.Text ):
     """
@@ -35,6 +32,7 @@ class Triples( data.Text ):
             dataset.peek = 'file does not exist'
             dataset.blurb = 'file purged from disk'
 
+
 class NTriples( Triples ):
     """
     The N-Triples triple data format
@@ -46,10 +44,10 @@ class NTriples( Triples ):
         handle = open(filename)
         line = handle.readline()
         handle.close()
-             
-        #@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .  
+
+        # @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         if re.compile( r'<[^>]*>\s<[^>]*>\s<[^>]*>\s\.' ).search( line ):
-            return True 
+            return True
         return False
 
     def set_peek( self, dataset, is_multi_byte=False ):
@@ -60,6 +58,7 @@ class NTriples( Triples ):
         else:
             dataset.peek = 'file does not exist'
             dataset.blurb = 'file purged from disk'
+
 
 class N3( Triples ):
     """
@@ -83,6 +82,7 @@ class N3( Triples ):
             dataset.peek = 'file does not exist'
             dataset.blurb = 'file purged from disk'
 
+
 class Turtle( Triples ):
     """
     The Turtle triple data format
@@ -94,10 +94,10 @@ class Turtle( Triples ):
         handle = open(filename)
         line = handle.readline()
         handle.close()
-             
-        #@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .  
+
+        # @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         if re.compile( r'@prefix\s+[^:]*:\s+<[^>]*>\s\.' ).search( line ):
-            return True 
+            return True
 
         return False
 
@@ -110,7 +110,8 @@ class Turtle( Triples ):
             dataset.peek = 'file does not exist'
             dataset.blurb = 'file purged from disk'
 
-#TODO: we might want to look at rdflib or a similar, larger lib/egg
+
+# TODO: we might want to look at rdflib or a similar, larger lib/egg
 class Rdf( xml.GenericXml, Triples ):
     """
     Resource Description Framework format (http://www.w3.org/RDF/).
@@ -137,16 +138,17 @@ class Rdf( xml.GenericXml, Triples ):
             dataset.peek = 'file does not exist'
             dataset.blurb = 'file purged from disk'
 
+
 class Jsonld( text.Json, Triples ):
     """
     The JSON-LD data format
     """
-    #format not defined in edam so we use the json format number 
-    edam_format = "format_3464" 
+    # format not defined in edam so we use the json format number
+    edam_format = "format_3464"
     file_ext = "jsonld"
 
     def sniff( self, filename ):
-        if self._looks_like_json( filename ): #super( text.Json, self ).sniff( filename )
+        if self._looks_like_json( filename ):
             f = open( filename, "r" )
             firstlines = "".join( f.readlines(5) )
             f.close()
@@ -163,4 +165,3 @@ class Jsonld( text.Json, Triples ):
         else:
             dataset.peek = 'file does not exist'
             dataset.blurb = 'file purged from disk'
-


### PR DESCRIPTION
- PEP-8 fixes for the file to ensure compliance with Galaxy coding standards.
- Restore as deprecated older reference to Rdf - so people with older datatype_conf.xml files will be warned of the problem.
- Use safe file handling in the sniffers (introducing generic infrastructure for doing this that the rest of the datatypes should be retro-fitted to use as well).
